### PR TITLE
Adding remote client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ ARG VARIANT="latest"
 ARG IMAGE="heisengarg/devbox"
 ARG USER="heisengarg"
 
+FROM quay.io/iovisor/bpftrace:latest as bpfsource
+
 FROM ${IMAGE}:${VARIANT}
 
 WORKDIR /home/${USER}/comdb2
@@ -34,6 +36,8 @@ RUN sudo apt-get update && sudo apt-get -y install --no-install-recommends \
     figlet               \
     iputils-ping         \
     net-tools
+
+COPY --from=bpfsource /usr/bin/bpftrace /usr/bin/bpftrace
 
 EXPOSE 5105 
 COPY ./entrypoint.sh /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ mkvol:
 	mkdir -p volumes
 
 .PHONY: runc
-runc: mkvol clean buildi
+runc: clean mkvol buildi
 	$(DOCKER) run --mount type=volume,source=comdb2-dbs,target="$(CNTHOME)/dbs" \
 	   	--mount type=volume,source=comdb2-opt-bb,target=/opt/bb/ \
 	   	--mount type=bind,source="$(SRCDIR)",target=$(CNTHOME)/comdb2,consistency=delegated \
@@ -57,7 +57,14 @@ clust: mkvol
 	   	--mount type=bind,source=$(LCLVOLDIR),target=$(CNTHOME)/volumes,consistency=delegated \
 		-it $(IMAGE):$(VERSION) clust $(DBNAME) $(CLUSTHOSTS)
 
-.PHONY: uclust
+.PHONY: clustbin
+clustbin: mkvol 
+	$(DOCKER) run -it --mount type=volume,source=comdb2-dbs,target=$(CNTHOME)/dbs \
+	   	--mount type=volume,source=comdb2-opt-bb,target=/opt/bb/ \
+	   	--mount type=bind,source=$(LCLVOLDIR),target=$(CNTHOME)/volumes,consistency=delegated \
+		-it $(IMAGE):$(VERSION) clustbin $(DBNAME) $(CLUSTHOSTS)
+
+.PHONY: clustbin uclust
 uclust: docker-compose.yaml
 	$(DOCKER) compose up -d
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ mkvol:
 	mkdir -p volumes
 
 .PHONY: runc
-runc: mkvol clean buildi
+runc: clean mkvol buildi
 	$(DOCKER) run --mount type=volume,source=comdb2-dbs,target="$(CNTHOME)/dbs" \
 	   	--mount type=volume,source=comdb2-opt-bb,target=/opt/bb/ \
 	   	--mount type=bind,source="$(SRCDIR)",target=$(CNTHOME)/comdb2,consistency=delegated \

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ IMAGE="heisengarg/comdb2-dev"
 VERSION="latest"
 CONTAINER="comdb2dev"
 CNTHOME="/home/heisengarg"
+CNTLRLOPTSLOC="$(CNTHOME)/lrl.options"
 
 # --- HOST --- #
 SRCDIR="$(shell pwd)/.."
 LCLVOLDIR="$(shell pwd)/volumes"
+LRLOPTSFILE="$(shell pwd)/lrl.options"
 
 # --- DB --- #
 CLUSTHOSTS="node1,node2,node3"
@@ -15,7 +17,7 @@ DBNAME="mogargdb"
 
 .PHONY: buildi
 buildi: Dockerfile
-	$(DOCKER) build -t $(IMAGE):$(VERSION) .
+	$(DOCKER) build --pull -t $(IMAGE):$(VERSION) .
 
 .PHONY: mkvol
 mkvol:
@@ -24,8 +26,20 @@ mkvol:
 .PHONY: runc
 runc: clean mkvol buildi
 	$(DOCKER) run --mount type=volume,source=comdb2-dbs,target="$(CNTHOME)/dbs" \
+		--cap-add=all \
 	   	--mount type=volume,source=comdb2-opt-bb,target=/opt/bb/ \
 	   	--mount type=bind,source="$(SRCDIR)",target=$(CNTHOME)/comdb2,consistency=delegated \
+	   	--mount type=bind,source=$(LCLVOLDIR),target=$(CNTHOME)/volumes \
+		-w $(CNTHOME) --hostname=$(CONTAINER) --name=$(CONTAINER)\
+	   	 -it $(IMAGE):$(VERSION) shell 
+
+.PHONY: runs
+runs: clean mkvol
+	$(DOCKER) run --mount type=volume,source=comdb2-dbs,target="$(CNTHOME)/dbs" \
+		--privileged \
+		--mount type=volume,source=comdb2-src,target=$(CNTHOME)/comdb2 \
+	   	--mount type=volume,source=comdb2-opt-bb,target=/opt/bb/ \
+	   	--mount type=bind,source="$(HOME)/.ssh",target=$(CNTHOME)/.ssh,consistency=cached \
 	   	--mount type=bind,source=$(LCLVOLDIR),target=$(CNTHOME)/volumes \
 		-w $(CNTHOME) --hostname=$(CONTAINER) --name=$(CONTAINER)\
 	   	 -it $(IMAGE):$(VERSION) shell 
@@ -33,12 +47,15 @@ runc: clean mkvol buildi
 .PHONY: newdb
 newdb:
 	$(DOCKER) run --mount type=volume,source=comdb2-dbs,target=$(CNTHOME)/dbs \
+		-e LRLFILEOPTSPATH=$(CNTLRLOPTSLOC) \
+		--mount type=bind,source=$(LRLOPTSFILE),target=$(CNTLRLOPTSLOC),readonly \
 	   	--mount type=volume,source=comdb2-opt-bb,target=/opt/bb/ \
-		-it $(IMAGE):$(VERSION) db $(DBNAME) 
+		-w $(CNTHOME) -it $(IMAGE):$(VERSION) db $(DBNAME) 
 
 .PHONY: run
 run: clean
 	$(DOCKER) run -p 5105:5105 -p 19000:19000 \
+		--cap-add=all \
 		--mount type=volume,source=comdb2-dbs,target=$(CNTHOME)/dbs \
 	   	--mount type=volume,source=comdb2-opt-bb,target=/opt/bb/ \
 		--name=$(CONTAINER) --hostname=$(CONTAINER) \
@@ -64,8 +81,8 @@ clustbin: mkvol
 	   	--mount type=bind,source=$(LCLVOLDIR),target=$(CNTHOME)/volumes,consistency=delegated \
 		-it $(IMAGE):$(VERSION) clustbin $(DBNAME) $(CLUSTHOSTS)
 
-.PHONY: clustbin uclust
-uclust: docker-compose.yaml
+.PHONY: uclust
+uclust: clustbin docker-compose.yaml
 	$(DOCKER) compose up -d
 
 .PHONY: sclust

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,11 @@ uclust: docker-compose.yaml
 
 .PHONY: sclust
 sclust: docker-compose.yaml 
-	$(DOCKER) compose down
+	$(DOCKER) compose stop
+
+.PHONY: dclust
+dclust: docker-compose.yaml 
+	$(DOCKER) compose down --remove-orphans 
 
 .PHONEY: lclust
 lclust: 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
       - ./volumes/node1-dbs:/home/heisengarg/dbs
     networks:
       - cluster-net
+      - client-net
     restart: unless-stopped
     cap_add:
       - ALL
@@ -25,6 +26,7 @@ services:
       - ./volumes/node2-dbs:/home/heisengarg/dbs
     networks:
       - cluster-net
+      - client-net
     restart: unless-stopped
     cap_add:
       - ALL
@@ -39,7 +41,22 @@ services:
       - ./volumes/node3-dbs:/home/heisengarg/dbs
     networks:
       - cluster-net
+      - client-net
     restart: unless-stopped
+    cap_add:
+      - ALL
+  comdb2-client:
+    container_name: client
+    hostname: client
+    image: heisengarg/comdb2-dev:latest
+    working_dir: /home/heisengarg/src
+    command: ["watch", "uptime"]
+    volumes:
+      - ../.:/home/heisengarg/src
+      - ./volumes/bin:/opt/bb/bin
+      - ./mogargdb.cfg:/opt/bb/etc/cdb2/config.d/mogargdb.cfg
+    networks:
+      - client-net
     cap_add:
       - ALL
 
@@ -52,3 +69,11 @@ networks:
       config:
       - subnet: 172.16.238.0/24
       - subnet: 2001:3984:3989::/64
+  client-net:
+    driver: bridge 
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.16.239.0/24
+      - subnet: 2001:3984:3990::/64

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,7 @@ new_db() {
 	# make a directory for logs
 	sudo mkdir -p /opt/bb/var/log/cdb2 && sudo chown -R $(whoami) /opt/bb/
 	$COMDB2 --create --dir "$DBSDIR/$DBNAME" "$DBNAME"
+	echo "logmsg.level debug" >>"$DBSDIR/$DBNAME/$DBNAME.lrl"
 }
 
 clusterize() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,8 @@ new_db() {
 
 	# make a directory for logs
 	sudo mkdir -p /opt/bb/var/log/cdb2 && sudo chown -R $(whoami) /opt/bb/
+	sudo mkdir -p "$DBSDIR/$DBNAME" && sudo chown -R $(whoami) "$DBSDIR/$DBNAME"
+
 	$COMDB2 --create --dir "$DBSDIR/$DBNAME" "$DBNAME"
 	echo "logmsg.level debug" >>"$DBSDIR/$DBNAME/$DBNAME.lrl"
 }

--- a/lrl.options
+++ b/lrl.options
@@ -1,0 +1,6 @@
+logmsg.level debug
+all_incoherent on
+decoupled_logputs off
+setattr REP_PROCESSORS 0
+setattr REP_WORKERS 0
+replicant_retry_on_not_durable on

--- a/lrl.options
+++ b/lrl.options
@@ -1,6 +1,1 @@
 logmsg.level debug
-all_incoherent on
-decoupled_logputs off
-setattr REP_PROCESSORS 0
-setattr REP_WORKERS 0
-replicant_retry_on_not_durable on


### PR DESCRIPTION
- Adds `bpftrace`
- Ability to have custom `lrl.options`
- Run a development container using `make runs`
- Now opens shells to each container in cluster
- Adds a client container that can be used to send queries to any node in the cluster
- default build type is `Debug`
- Just copy the binaries over to the nodes in the cluster using `make clustbin` rather than the full `dbs`.