### PR TITLE
Add ssh'ing capabilites in cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,10 +49,13 @@ RUN sudo apt-get update && sudo apt-get -y install --no-install-recommends \
     cscope               \
     figlet               \
     iputils-ping         \
-    net-tools
+    net-tools            \
+    sshpass
 
 COPY --from=bpfsource /usr/bin/bpftrace /usr/bin/bpftrace
 COPY --from=perfsource /home/heisengarg/linux-5.10.25/tools/perf/perf /usr/bin/perf
+
+RUN sudo service ssh restart 
 
 EXPOSE 5105 
 COPY ./entrypoint.sh /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,7 @@ client:
 	./client.sh -d $(DBNAME) -n $(CLUSTHOSTS)
 
 .PHONY: clean
-clean: sclust
-	rm -rf volumes
+clean:
 	docker rm -f $(CONTAINER)
 
 .PHONY: logs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,14 +50,20 @@ services:
     hostname: client
     image: heisengarg/comdb2-dev:latest
     working_dir: /home/heisengarg/src
-    command: ["watch", "uptime"]
+    command: ["diskeys", "node1,node2,node3"]
+    environment:
+     - CLUSTER="node1 node2 node3"
     volumes:
-      - ../.:/home/heisengarg/src
+      - comdb2-src:/home/heisengarg/src
       - ./volumes/bin:/opt/bb/bin
     networks:
       - client-net
     cap_add:
       - ALL
+
+volumes:
+  comdb2-src:
+    external: true
 
 networks:
   cluster-net:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -182,7 +182,7 @@ run_client() {
 }
 
 distribute_ssh_keys() {
-    keep_running=0
+	keep_running=0
 
 	if [ -z "$1" ]; then
 		echo "No hosts passed. Pass hosts as mach1,mach2,..,machn"
@@ -191,9 +191,9 @@ distribute_ssh_keys() {
 
 	IFS=',' read -rA hosts <<<"$1"
 
-    if [ -n "$2" ]; then 
-        keep_running=1;
-    fi 
+	if [ -n "$2" ]; then
+		keep_running=1
+	fi
 
 	KEYLOC="$HOMEDIR/.ssh"
 	KEYFILE="id_clust"
@@ -212,12 +212,12 @@ EOF
 		if [ "$(sudo ssh -i $KEYLOC/$KEYFILE -o StrictHostKeyChecking=no heisengarg@"$host" hostname)" != $host ]; then
 			echo "Couldn't reach out to $host" >&2
 			exit 1
-        else
-            echo "Success ssh'ing to $host"
+		else
+			echo "Success ssh'ing to $host"
 		fi
 	done
 
-    [[ "$keep_running" != 0 ]] && watch uptime
+	[[ "$keep_running" != 0 ]] && watch uptime
 }
 
 sudo service ssh restart


### PR DESCRIPTION
Now `comdb2-client` service comes up  and distributes the keys for `ssh` to the cluster.  Now we can do,

```shell
make uclust && docker exec -it -e CLUSTER="node1 node2 node3" -w /home/heisengarg/src/tests make
```

to run tests. Also, we can enhance `clusterize` to copy databases over ssh rather than to bind volumes. Would be way more performant.