### PR TITLE
Enable all perf features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,20 @@ FROM ${IMAGE}:${VARIANT} as perfsource
 
 USER root
 
+# libelf-dev for perf probe
+# libdbw-dev for perf DWARF
 RUN apt-get update &&  apt-get -y install --no-install-recommends \
-    wget bison flex xz-utils
+    libelf-dev libbfd-dev libcap-dev libnuma-dev \
+    libunwind-dev libzstd-dev libssl-dev \
+    systemtap-sdt-dev libslang2-dev libperl-dev \
+    libiberty-dev libbabeltrace-dev \
+    libdw-dev \
+    wget bison flex xz-utils 
 
 RUN  wget https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.10.25.tar.xz \
      && tar -xf linux-5.10.25.tar.xz \
      && cd linux-5.10.25/tools/perf \
-     && make -j 8 -C . \
+     && make -j 16 -C . \
      && make install
 
 FROM ${IMAGE}:${VARIANT}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,10 @@ version: "3.9"
 services:
   comdb2-node1:
     container_name: node1
-    hostname: node1 
+    hostname: node1
     image: heisengarg/comdb2-dev:latest
     working_dir: /home/heisengarg
+    privileged: true
     command: ["run", "mogargdb"]
     volumes:
       - ./volumes/bin:/opt/bb/bin
@@ -21,6 +22,7 @@ services:
     hostname: node2
     image: heisengarg/comdb2-dev:latest
     working_dir: /home/heisengarg
+    privileged: true
     command: ["run", "mogargdb"]
     volumes:
       - ./volumes/bin:/opt/bb/bin
@@ -37,6 +39,7 @@ services:
     hostname: node3
     image: heisengarg/comdb2-dev:latest
     working_dir: /home/heisengarg
+    privileged: true
     command: ["run", "mogargdb"]
     volumes:
       - ./volumes/bin:/opt/bb/bin
@@ -53,6 +56,7 @@ services:
     hostname: client
     image: heisengarg/comdb2-dev:latest
     working_dir: /home/heisengarg/src
+    privileged: true
     command: ["diskeys", "node1,node2,node3"]
     environment:
      - CLUSTER="node1 node2 node3"
@@ -79,7 +83,7 @@ networks:
       - subnet: 172.16.238.0/24
       - subnet: 2001:3984:3989::/64
   client-net:
-    driver: bridge 
+    driver: bridge
     enable_ipv6: true
     ipam:
       driver: default

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -232,6 +232,8 @@ EOF
 }
 
 sudo service ssh restart 2>&1 >/dev/null
+sudo sysctl -w kernel.randomize_va_space=0 2>&1 >/dev/null ||
+	echo "[WARNING] Not running in privileged mode. Address randomization is still enabled"
 
 case "$1" in
 build)


### PR DESCRIPTION
- Enables all features for `perf` by building `perfsource` with required libraries.
- `sysctl -w kernel.randomize_va_space=0 2>&1 >/dev/null` doesn't work. Have to recheck